### PR TITLE
Fix panicking in ClientOAuth2 initialization

### DIFF
--- a/ballerina/modules/soap/client.bal
+++ b/ballerina/modules/soap/client.bal
@@ -43,13 +43,19 @@ public isolated client class Client {
                 (authConfig is http:BearerTokenConfig ? authConfig : {...authConfig});
         self.clientConfig = auth.cloneReadOnly();
 
-        http:ClientOAuth2Handler|http:ClientBearerTokenAuthHandler httpHandlerResult;
+        http:ClientOAuth2Handler|http:ClientBearerTokenAuthHandler|error httpHandlerResult;
+        
         if auth is http:OAuth2RefreshTokenGrantConfig {
-            httpHandlerResult = new http:ClientOAuth2Handler(auth);
+            httpHandlerResult = trap new http:ClientOAuth2Handler(auth);
         } else {
             httpHandlerResult = new http:ClientBearerTokenAuthHandler(auth);
         }
-        self.clientHandler = httpHandlerResult;
+
+        if httpHandlerResult is http:ClientOAuth2Handler|http:ClientBearerTokenAuthHandler {
+            self.clientHandler = httpHandlerResult;
+        } else {
+            return error(utils:CLIENT_INIT_ERROR_MSG + httpHandlerResult.message(), httpHandlerResult);
+        }
 
         http:Client|http:ClientError httpClientResult = new (config.baseUrl, httpClientConfig);
 


### PR DESCRIPTION
# Description

Fix panicking in ClientOAuth2/BearerTokenAuthProvider initialization

Re-add trap() statements which removed in https://github.com/ballerina-platform/module-ballerinax-salesforce/pull/373

Since oauth2 provider may return panic in [client_oauth2_provider.bal#L207](https://github.com/ballerina-platform/module-ballerina-oauth2/blob/master/ballerina/client_oauth2_provider.bal#L207)